### PR TITLE
Set web `--base-href` for GitHub Pages and bump package version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Build web release
         run: |
           flutter build web --release \
-            --base-href "/"
+            --base-href "/PasCurtain/"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: pas_curtain
 description: PasCurtain — a multiplatform password and email breach checker using the pwnedpasswords API with secure password suggestions.
 publish_to: 'none'
 
-version: 1.2.3+1
+version: 1.2.4+1
 
 environment:
   sdk: '>=3.9.0 <4.0.0'


### PR DESCRIPTION
### Motivation

- Ensure the Flutter web build is served from the repository subpath on GitHub Pages rather than the site root. 
- Bump the package version to reflect a new release.

### Description

- Change the web build `--base-href` in `.github/workflows/release.yml` from `/` to `/PasCurtain/` so the PWA assets resolve correctly when hosted on GitHub Pages. 
- Update `version` in `pubspec.yaml` from `1.2.3+1` to `1.2.4+1` to mark the new release.

### Testing

- No automated tests were run as part of this change; CI workflows were not triggered by this edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5699fb148321a9232a6aa6b79c16)